### PR TITLE
feat: accept promises on config.onRetryAttempt

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,29 @@ const res = await axios({
 });
 ```
 
+If the logic in onRetryAttempt requires to be asynchronous, you can return a promise, then retry will be executed only after the promise is resolved:
+
+```js
+const res = await axios({
+  url: 'https://test.local',
+  raxConfig: {
+    onRetryAttempt: (err) => {
+      return new Promise((resolve, reject) => {
+        // call a custom asynchronous function
+        refreshToken(err, function(token, error) {
+          if (!error) {
+            window.localStorage.setItem('token',token);
+            resolve();
+          } else {
+            reject();
+          }
+        })
+      });
+    }
+  }
+});
+```
+
 Or if you want, you can just decide if it should retry or not:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 # retry-axios
+> Use Axios interceptors to automatically retry failed requests.  Super flexible. Built in exponential backoff.
 
 [![NPM Version][npm-image]][npm-url]
 [![CircleCI][circle-image]][circle-url]
 [![Dependency Status][david-image]][david-url]
-[![devDependency Status][david-dev-image]][david-dev-url]
 [![Known Vulnerabilities][snyk-image]][snyk-url]
 [![codecov][codecov-image]][codecov-url]
-[![Greenkeeper badge][greenkeeper-image]][greenkeeper-url]
 [![style badge][gts-image]][gts-url]
 
-Use Axios interceptors to automatically retry failed requests.  Super flexible. Built in exponential backoff.
 
 ## Installation
 
@@ -108,16 +106,12 @@ This library attaches an `interceptor` to an axios instance you pass to the API.
 ## License
 [Apache-2.0](LICENSE)
 
-[circle-image]: https://circleci.com/gh/JustinBeckwith/retry-axios.svg?style=svg
+[circle-image]: https://circleci.com/gh/JustinBeckwith/retry-axios.svg?style=shield
 [circle-url]: https://circleci.com/gh/JustinBeckwith/retry-axios
 [codecov-image]: https://codecov.io/gh/JustinBeckwith/retry-axios/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/JustinBeckwith/retry-axios
 [david-image]: https://david-dm.org/JustinBeckwith/retry-axios.svg
 [david-url]: https://david-dm.org/JustinBeckwith/retry-axios
-[david-dev-image]: https://david-dm.org/JustinBeckwith/retry-axios/dev-status.svg
-[david-dev-url]: https://david-dm.org/JustinBeckwith/retry-axios?type=dev
-[greenkeeper-image]: https://badges.greenkeeper.io/JustinBeckwith/retry-axios.svg
-[greenkeeper-url]: https://greenkeeper.io/
 [gts-image]: https://img.shields.io/badge/code%20style-Google%20%E2%98%82%EF%B8%8F-blue.svg
 [gts-url]: https://www.npmjs.com/package/gts
 [npm-image]: https://img.shields.io/npm/v/retry-axios.svg

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "nock": "^10.0.0",
     "nyc": "^13.0.0",
     "source-map-support": "^0.5.6",
-    "typescript": "~3.1.0"
+    "typescript": "~3.2.0"
   },
   "files": [
     "build/src"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "js-green-licenses": "^0.5.0",
     "mocha": "^5.2.0",
     "nock": "^10.0.0",
-    "nyc": "^12.0.2",
+    "nyc": "^13.0.0",
     "source-map-support": "^0.5.6",
     "typescript": "~3.1.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,25 +118,27 @@ function onError(err: AxiosError) {
     return Promise.reject(err);
   }
 
-  // Calculate time to wait with exponential backoff.
-  // Formula: (2^c - 1 / 2) * 1000
-  const delay = (Math.pow(2, config.currentRetryAttempt) - 1) / 2 * 1000;
-
-  // We're going to retry!  Incremenent the counter.
-  (err.config as RaxConfig).raxConfig!.currentRetryAttempt! += 1;
-
   // Create a promise that invokes the retry after the backOffDelay
-  const backoff = new Promise(resolve => {
+  const onBackoffPromise = new Promise((resolve) => {
+    // Calculate time to wait with exponential backoff.
+    // Formula: (2^c - 1 / 2) * 1000
+    const delay = (Math.pow(2, config.currentRetryAttempt!) - 1) / 2 * 1000;
+
+    // We're going to retry!  Incremenent the counter.
+    (err.config as RaxConfig).raxConfig!.currentRetryAttempt! += 1;
     setTimeout(resolve, delay);
   });
 
   // Notify the user if they added an `onRetryAttempt` handler
-  if (config.onRetryAttempt) {
-    config.onRetryAttempt(err);
-  }
+  const onRetryAttemptPromise = (config.onRetryAttempt) ?
+      Promise.resolve(config.onRetryAttempt(err)) :
+      Promise.resolve();
 
   // Return the promise in which recalls axios to retry the request
-  return backoff.then(() => config.instance!.request(err.config));
+  return Promise.resolve()
+      .then(() => onBackoffPromise)
+      .then(() => onRetryAttemptPromise)
+      .then(() => config.instance!.request(err.config));
 }
 
 /**

--- a/test/index.ts
+++ b/test/index.ts
@@ -170,7 +170,7 @@ describe('retry-axios', () => {
     scopes.forEach(s => s.done());
   });
 
-  it.only('should notify on retry attempts as a promise', async () => {
+  it('should notify on retry attempts as a promise', async () => {
     const scopes =
         [nock(url).get('/').reply(500), nock(url).get('/').reply(200, 'toast')];
     interceptorId = rax.attach();

--- a/test/index.ts
+++ b/test/index.ts
@@ -25,22 +25,22 @@ describe('retry-axios', () => {
     } catch (e) {
       scope.done();
       const config = rax.getConfig(e);
-      assert.equal(config!.currentRetryAttempt, 3);
-      assert.equal(config!.retry, 3);
-      assert.equal(config!.noResponseRetries, 2);
-      assert.equal(config!.retryDelay, 100);
-      assert.equal(config!.instance, axios);
+      assert.equal(config!.currentRetryAttempt, 3, 'currentRetryAttempt');
+      assert.equal(config!.retry, 3, 'retry');
+      assert.equal(config!.noResponseRetries, 2, 'noResponseRetries');
+      assert.equal(config!.retryDelay, 100, 'retryDelay');
+      assert.equal(config!.instance, axios, 'axios');
       const expectedMethods = ['GET', 'HEAD', 'PUT', 'OPTIONS', 'DELETE'];
       for (const method of config!.httpMethodsToRetry!) {
-        assert(expectedMethods.indexOf(method) > -1);
+        assert(expectedMethods.indexOf(method) > -1, `exected method: $method`);
       }
       const expectedStatusCodes = [[100, 199], [429, 429], [500, 599]];
       const statusCodesToRetry = config!.statusCodesToRetry!;
       for (let i = 0; i < statusCodesToRetry.length; i++) {
         const [min, max] = statusCodesToRetry[i];
         const [expMin, expMax] = expectedStatusCodes[i];
-        assert.equal(min, expMin);
-        assert.equal(max, expMax);
+        assert.equal(min, expMin, `status code min`);
+        assert.equal(max, expMax, `status code max`);
       }
       return;
     }
@@ -162,6 +162,29 @@ describe('retry-axios', () => {
           const cfg = rax.getConfig(err);
           assert.equal(cfg!.currentRetryAttempt, 1);
           flipped = true;
+        }
+      }
+    };
+    const res = await axios(config);
+    assert.equal(flipped, true);
+    scopes.forEach(s => s.done());
+  });
+
+  it.only('should notify on retry attempts as a promise', async () => {
+    const scopes =
+        [nock(url).get('/').reply(500), nock(url).get('/').reply(200, 'toast')];
+    interceptorId = rax.attach();
+    let flipped = false;
+    const config: RaxConfig = {
+      url,
+      raxConfig: {
+        onRetryAttempt: (err) => {
+          return new Promise((resolve, reject) => {
+            const cfg = rax.getConfig(err);
+            assert.equal(cfg!.currentRetryAttempt, 1);
+            flipped = true;
+            resolve();
+          });
         }
       }
     };


### PR DESCRIPTION
We had to implement an onRetryAttempt using a Promise in order to refresh our access token, then retry the call.