### PR TITLE
fix: include files in the release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,4 +76,5 @@ jobs:
     steps:
       - checkout
       - run: npm install
+      - run: npm run compile
       - run: npx semantic-release


### PR DESCRIPTION
The `0.4.0` release went out without any of the JavaScript.  This updates the build script to compile before doing the release. 