### PR TITLE
Fix error when a method call inside axios interceptor throws error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,9 @@ function onFulfilled(res: AxiosResponse) {
 }
 
 function onError(err: AxiosError) {
+  if (!err.config) {
+    return Promise.reject(err);
+  }
   const config = (err.config as RaxConfig).raxConfig || {};
   config.currentRetryAttempt = config.currentRetryAttempt || 0;
   config.retry =


### PR DESCRIPTION
Fix error when a method called inside the axios interceptor throws a custom error

Fix #32