### PR TITLE
fix: transpile to es5

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,9 @@
 {
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
+    "outDir": "build",
     "rootDir": ".",
-    "outDir": "build"
+    "target": "es5"
   },
-  "include": [
-    "src/*.ts",
-    "test/*.ts"
-  ]
+  "include": ["src/*.ts", "test/*.ts"]
 }


### PR DESCRIPTION
When using the suggested [babel-loader config](https://github.com/babel/babel-loader#usage) in Webpack (exclude `node_modules`) retry-axios causes parsing error in IE due to arrow functions.

Updating the TypeScript target to ES5 enables compatibility without further configuration of Webpack.