### PR TITLE
Making sure err has a config object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ function onFulfilled(res: AxiosResponse) {
 }
 
 function onError(err: AxiosError) {
+  if (!Object.prototype.hasOwnProperty(err,'config')) err.config = {};
   const config = (err.config as RaxConfig).raxConfig || {};
   config.currentRetryAttempt = config.currentRetryAttempt || 0;
   config.retry =


### PR DESCRIPTION
In certain error circumstances - there is no `err.config` - this generates an error per #59 
For example - passing a URL Object instead of a url string.

This ensures that there is an err.config to prevent the above.
Allowing an error like the below to be generated:
```text
{ TypeError [ERR_INVALID_ARG_TYPE]: The "url" argument must be of type string. Received type object
    at Url.parse (url.js:154:11)
    at Object.urlParse [as parse] (url.js:148:13)
    at dispatchHttpRequest (/usr/src/app/node_modules/axios/lib/adapters/http.js:67:22)
    at new Promise (<anonymous>)
    at httpAdapter (/usr/src/app/node_modules/axios/lib/adapters/http.js:20:10)
    at dispatchRequest (/usr/src/app/node_modules/axios/lib/core/dispatchRequest.js:59:10)
    at process._tickCallback (internal/process/next_tick.js:68:7)
  config:
   { raxConfig:
      { currentRetryAttempt: 0,
        retry: 3,
        retryDelay: 100,
        instance: [Function],
        httpMethodsToRetry: [Array],
        noResponseRetries: 2,
        statusCodesToRetry: [Array] } } }
```