### PR TITLE
fix: Ensure the existence of a config object on error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ function onFulfilled(res: AxiosResponse) {
 }
 
 function onError(err: AxiosError) {
-  const config = (err.config as RaxConfig).raxConfig || {};
+  const config = getConfig(err) || {};
   config.currentRetryAttempt = config.currentRetryAttempt || 0;
   config.retry =
     config.retry === undefined || config.retry === null ? 3 : config.retry;


### PR DESCRIPTION
This is a PR that ftries to fix the exact same error as reported by @troykelly  on PR#70

Copy pasting his description :

In certain error circumstances - there is no err.config - this generates an error per #59
For example - passing a URL Object instead of a url string.

This ensures that there is an err.config to prevent the above.
Allowing an error like the below to be generated:

```
{ TypeError [ERR_INVALID_ARG_TYPE]: The "url" argument must be of type string. Received type object
    at Url.parse (url.js:154:11)
    at Object.urlParse [as parse] (url.js:148:13)
    at dispatchHttpRequest (/usr/src/app/node_modules/axios/lib/adapters/http.js:67:22)
    at new Promise (<anonymous>)
    at httpAdapter (/usr/src/app/node_modules/axios/lib/adapters/http.js:20:10)
    at dispatchRequest (/usr/src/app/node_modules/axios/lib/core/dispatchRequest.js:59:10)
    at process._tickCallback (internal/process/next_tick.js:68:7)
  config:
   { raxConfig:
      { currentRetryAttempt: 0,
        retry: 3,
        retryDelay: 100,
        instance: [Function],
        httpMethodsToRetry: [Array],
        noResponseRetries: 2,
        statusCodesToRetry: [Array] } } }
```

This is a second PR in order to:

1. Fix the commits / PR formatting checks that were reported by the bots
2. The fix itself uses an already defined method in order to extract the `raxConfig` instead of relying on `hasOwnProperties`