### PR TITLE
fix: Use exported accessor to get the raxConfig object on error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "retry-axios",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Retry HTTP requests with Axios.",
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,6 +122,8 @@ function onError(err: AxiosError) {
   config.statusCodesToRetry = config.statusCodesToRetry || retryRanges;
 
   // Put the config back into the err
+  err = err || {};
+  err.config = err.config || {};
   (err.config as RaxConfig).raxConfig = config;
 
   // Determine if we should retry the request

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,6 @@ function onError(err: AxiosError) {
   config.statusCodesToRetry = config.statusCodesToRetry || retryRanges;
 
   // Put the config back into the err
-  err = err || {};
   err.config = err.config || {};
   (err.config as RaxConfig).raxConfig = config;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ function onFulfilled(res: AxiosResponse) {
 }
 
 function onError(err: AxiosError) {
-  const config = (err.config as RaxConfig).raxConfig || {};
+  const config = getConfig(err) || {};
   config.currentRetryAttempt = config.currentRetryAttempt || 0;
   config.retry =
     config.retry === undefined || config.retry === null ? 3 : config.retry;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "build"
+    "outDir": "build",
+    "target": "es5",
+    "lib": ["es6", "dom"]
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
Same as PR #72 and PR #70, still trying to pass all bots checks.

This is a PR that tries to fix the exact same error as reported by @troykelly on PR#70

Copy pasting his description :

In certain error circumstances - there is no err.config - this generates an error per #59
For example - passing a URL Object instead of a url string.

This ensures that there is an err.config to prevent the above.
Allowing an error like the below to be generated:

```
{ TypeError [ERR_INVALID_ARG_TYPE]: The "url" argument must be of type string. Received type object
    at Url.parse (url.js:154:11)
    at Object.urlParse [as parse] (url.js:148:13)
    at dispatchHttpRequest (/usr/src/app/node_modules/axios/lib/adapters/http.js:67:22)
    at new Promise (<anonymous>)
    at httpAdapter (/usr/src/app/node_modules/axios/lib/adapters/http.js:20:10)
    at dispatchRequest (/usr/src/app/node_modules/axios/lib/core/dispatchRequest.js:59:10)
    at process._tickCallback (internal/process/next_tick.js:68:7)
  config:
   { raxConfig:
      { currentRetryAttempt: 0,
        retry: 3,
        retryDelay: 100,
        instance: [Function],
        httpMethodsToRetry: [Array],
        noResponseRetries: 2,
        statusCodesToRetry: [Array] } } }
````
This is a second PR in order to:

Fix the commits / PR formatting checks that were reported by the bots
The fix itself uses an already defined method in order to extract the raxConfig instead of relying on hasOwnProperties