### PR TITLE
chore: drop support for nodejs 8.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,17 +3,15 @@ workflows:
   version: 2
   test:
     jobs:
-      - node8
       - node10
-      - node11
       - node12
+      - node13
       - lint
       - publish_npm:
           requires:
-            - node8
             - node10
-            - node11
             - node12
+            - node13
             - lint
           filters:
             branches:
@@ -26,19 +24,9 @@ unit_tests: &unit_tests
     - run: npm test
 
 jobs:
-  node8:
-    docker:
-      - image: node:8
-        user: node
-    <<: *unit_tests
   node10:
     docker:
       - image: node:10
-        user: node
-    <<: *unit_tests
-  node11:
-    docker:
-      - image: node:11
         user: node
     <<: *unit_tests
   node12:
@@ -46,16 +34,21 @@ jobs:
       - image: node:12
         user: node
     <<: *unit_tests
+  node13:
+    docker:
+      - image: node:13
+        user: node
+    <<: *unit_tests
   lint:
     docker:
-      - image: node:11
+      - image: node:12
     steps:
       - checkout
       - run: npm install
       - run: npm run lint
   coverage:
     docker:
-      - image: node:11
+      - image: node:12
     steps:
       - checkout
       - run: npm install
@@ -63,7 +56,7 @@ jobs:
       - run: npm run coverage
   publish_npm:
     docker:
-      - image: node:11
+      - image: node:12
     steps:
       - checkout
       - run: npm install

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "retry-axios",
-  "version": "0.3.2",
+  "version": "0.0.0",
   "description": "Retry HTTP requests with Axios.",
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
BREAKING CHANGE: Drops support for node.js 8.x, which is EOL. 