### PR TITLE
test: should accept defaults on a new instance

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -129,6 +129,25 @@ describe('retry-axios', () => {
     assert.fail('Expected to throw');
   });
 
+  it('should accept defaults on a new instance', async () => {
+    const scopes = [
+      nock(url).get('/').times(2).reply(500),
+      nock(url).get('/').reply(200, '🥧'),
+    ];
+    const ax = axios.create();
+    ax.defaults.raxConfig = {
+      retry: 3,
+      instance: ax,
+      onRetryAttempt: evt => {
+        console.log(`attempt #${evt.config!.raxConfig?.currentRetryAttempt}`);
+      },
+    };
+    interceptorId = rax.attach(ax);
+    const res = await ax.get(url);
+    assert.strictEqual(res.data, '🥧');
+    scopes.forEach(s => s.done());
+  });
+
   it('should not retry on 4xx errors', async () => {
     const scope = nock(url).get('/').reply(404);
     interceptorId = rax.attach();


### PR DESCRIPTION
Fixes #90 

Context for future me. The issue here boils down to the way axios merges their default configuration along with request level configuration.  The merging code goes through a named set of parameters, and only merges known properties.  `raxConfig` is pinned on the config, so it is not in said named list.  The offending code is here:
https://github.com/axios/axios/blob/master/lib/core/mergeConfig.js#L19

```js
var valueFromConfig2Keys = ['url', 'method', 'params', 'data'];
  var mergeDeepPropertiesKeys = ['headers', 'auth', 'proxy'];
  var defaultToConfig2Keys = [
    'baseURL', 'url', 'transformRequest', 'transformResponse', 'paramsSerializer',
    'timeout', 'withCredentials', 'adapter', 'responseType', 'xsrfCookieName',
    'xsrfHeaderName', 'onUploadProgress', 'onDownloadProgress',
    'maxContentLength', 'validateStatus', 'maxRedirects', 'httpAgent',
    'httpsAgent', 'cancelToken', 'socketPath'
  ];
```

We would need to somehow add `raxConfig` to the list of known `mergeDeepPropertiesKeys`, which is in no way at all extensible today.  I have no idea how to fix this. 