### PR TITLE
fix: Don't store counter on input config object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ function onError(err: AxiosError) {
     normalizeArray(config.statusCodesToRetry) || retryRanges;
 
   // Put the config back into the err
-  (err.config as RaxConfig).raxConfig = config;
+  (err.config as RaxConfig).raxConfig = { ...config };
 
   // Determine if we should retry the request
   const shouldRetryFn = config.shouldRetry || shouldRetryRequest;

--- a/test/index.ts
+++ b/test/index.ts
@@ -331,4 +331,29 @@ describe('retry-axios', () => {
     }
     assert.fail('Expected to throw');
   });
+
+  it('should reset error counter upon success', async () => {
+    const scopes = [
+      nock(url)
+        .get('/')
+        .times(2)
+        .reply(500),
+      nock(url)
+        .get('/')
+        .reply(200, 'milk'),
+      nock(url)
+        .get('/')
+        .reply(500),
+      nock(url)
+        .get('/')
+        .reply(200, 'toast'),
+    ];
+    interceptorId = rax.attach();
+    const cfg: rax.RaxConfig = { url, raxConfig: { retry: 2 } };
+    const res = await axios(cfg);
+    assert.strictEqual(res.data, 'milk');
+    const res2 = await axios(cfg);
+    assert.strictEqual(res2.data, 'toast');
+    scopes.forEach(s => s.done());
+  });
 });


### PR DESCRIPTION
The currentRetryAttempt is still stored on the configuration for backward compatibility.

Fixes #61.