### PR TITLE
fix: added check for cancel tokens

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,7 @@ function normalizeArray<T>(obj?: T[]): T[] | undefined {
 
 function onError(err: AxiosError) {
   if (axios.isCancel(err)) {
-    return err;
+    return Promise.reject(err);
   }
 
   const config = getConfig(err) || {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,10 @@ function normalizeArray<T>(obj?: T[]): T[] | undefined {
 }
 
 function onError(err: AxiosError) {
+  if (axios.isCancel(err)) {
+    return err;
+  }
+
   const config = getConfig(err) || {};
   config.currentRetryAttempt = config.currentRetryAttempt || 0;
   config.retry =

--- a/test/index.ts
+++ b/test/index.ts
@@ -356,4 +356,26 @@ describe('retry-axios', () => {
     assert.strictEqual(res2.data, 'toast');
     scopes.forEach(s => s.done());
   });
+
+  it('should ignore requests that have been canceled', async () => {
+    const scope = nock(url)
+      .get('/')
+      .delay(200)
+      .reply(200, 'toast');
+    interceptorId = rax.attach();
+    try {
+      const src = axios.CancelToken.source();
+      const cfg: rax.RaxConfig = {
+        url,
+        raxConfig: { retry: 2 },
+        cancelToken: src.token
+      };
+      const req = axios(cfg);
+      src.cancel();
+      const res = await req;
+      throw new Error('The canceled request completed.');
+    } catch (err) {
+      assert.strictEqual(axios.isCancel(err), true);
+    } 
+  });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -368,7 +368,7 @@ describe('retry-axios', () => {
       const cfg: rax.RaxConfig = {
         url,
         raxConfig: { retry: 2 },
-        cancelToken: src.token
+        cancelToken: src.token,
       };
       const req = axios(cfg);
       src.cancel();
@@ -376,6 +376,6 @@ describe('retry-axios', () => {
       throw new Error('The canceled request completed.');
     } catch (err) {
       assert.strictEqual(axios.isCancel(err), true);
-    } 
+    }
   });
 });


### PR DESCRIPTION
```typescript
168: // Put the config back into the err
169: (err.config as RaxConfig).raxConfig = { ...config };
```

When canceling a request with a cancel token, a property access exception is thrown at line 169 ("TypeError: err.config is undefined") because the the received cancel error doesn't contain a config property. I've added a check to ignore cancel tokens since there's no reason to retry then anyway.