### PR TITLE
fix: cannot set propery raxConfig of undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ function onError(err: AxiosError) {
     normalizeArray(config.statusCodesToRetry) || retryRanges;
 
   // Put the config back into the err
-  err.config = error.config || {}; // allow for wider range of errors
+  err.config = err.config || {}; // allow for wider range of errors
   (err.config as RaxConfig).raxConfig = {...config};
 
   // Determine if we should retry the request

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,7 @@ function onError(err: AxiosError) {
     normalizeArray(config.statusCodesToRetry) || retryRanges;
 
   // Put the config back into the err
+  err.config = error.config || {}; // allow for wider range of errors
   (err.config as RaxConfig).raxConfig = {...config};
 
   // Determine if we should retry the request


### PR DESCRIPTION
There are cases when an error may be thrown that does not have a config attribute as required by `AxiosError`. This error could be from Axios internals or more likely another interceptor or custom adapter. Regardless, this fix is a simple defensive approach to avoid hiding the underlying error.

closes #95 