### PR TITLE
feat: allow retryDelay to be 0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,12 +131,9 @@ function onError(err: AxiosError) {
 
   const config = getConfig(err) || {};
   config.currentRetryAttempt = config.currentRetryAttempt || 0;
-  config.retry =
-    config.retry === undefined || config.retry === null ? 3 : config.retry;
+  config.retry = typeof config.retry === 'number' ? config.retry : 3;
   config.retryDelay =
-    config.retryDelay === undefined || config.retryDelay === null
-      ? 100
-      : config.retryDelay;
+    typeof config.retryDelay === 'number' ? config.retryDelay : 100;
   config.instance = config.instance || axios;
   config.backoffType = config.backoffType || 'exponential';
   config.httpMethodsToRetry = normalizeArray(config.httpMethodsToRetry) || [
@@ -147,9 +144,7 @@ function onError(err: AxiosError) {
     'DELETE',
   ];
   config.noResponseRetries =
-    config.noResponseRetries === undefined || config.noResponseRetries === null
-      ? 2
-      : config.noResponseRetries;
+    typeof config.noResponseRetries === 'number' ? config.noResponseRetries : 2;
 
   // If this wasn't in the list of status codes where we want
   // to automatically retry, return.

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,10 @@ function onError(err: AxiosError) {
   config.currentRetryAttempt = config.currentRetryAttempt || 0;
   config.retry =
     config.retry === undefined || config.retry === null ? 3 : config.retry;
-  config.retryDelay = config.retryDelay ?? 100;
+  config.retryDelay =
+    config.retryDelay === undefined || config.retryDelay === null
+      ? 100
+      : config.retryDelay;
   config.instance = config.instance || axios;
   config.backoffType = config.backoffType || 'exponential';
   config.httpMethodsToRetry = normalizeArray(config.httpMethodsToRetry) || [

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ function onError(err: AxiosError) {
   config.currentRetryAttempt = config.currentRetryAttempt || 0;
   config.retry =
     config.retry === undefined || config.retry === null ? 3 : config.retry;
-  config.retryDelay = config.retryDelay || 100;
+  config.retryDelay = config.retryDelay ?? 100;
   config.instance = config.instance || axios;
   config.backoffType = config.backoffType || 'exponential';
   config.httpMethodsToRetry = normalizeArray(config.httpMethodsToRetry) || [

--- a/test/index.ts
+++ b/test/index.ts
@@ -342,4 +342,58 @@ describe('retry-axios', () => {
     }
     assert.strictEqual(scopes[1].isDone(), false);
   });
+
+  it('should accept 0 for config.retryDelay', async () => {
+    const scope = nock(url).get('/').replyWithError({code: 'ETIMEDOUT'});
+    interceptorId = rax.attach();
+    const config: AxiosRequestConfig = {
+      url,
+      raxConfig: {retryDelay: 0},
+    };
+    try {
+      await axios(config);
+    } catch (e) {
+      const cfg = rax.getConfig(e);
+      assert.strictEqual(cfg!.retryDelay, 0);
+      scope.isDone();
+      return;
+    }
+    assert.fail('Expected to throw');
+  });
+
+  it('should accept 0 for config.retry', async () => {
+    const scope = nock(url).get('/').replyWithError({code: 'ETIMEDOUT'});
+    interceptorId = rax.attach();
+    const config: AxiosRequestConfig = {
+      url,
+      raxConfig: {retry: 0},
+    };
+    try {
+      await axios(config);
+    } catch (e) {
+      const cfg = rax.getConfig(e);
+      assert.strictEqual(cfg!.retry, 0);
+      scope.isDone();
+      return;
+    }
+    assert.fail('Expected to throw');
+  });
+
+  it('should accept 0 for config.noResponseRetries', async () => {
+    const scope = nock(url).get('/').replyWithError({code: 'ETIMEDOUT'});
+    interceptorId = rax.attach();
+    const config: AxiosRequestConfig = {
+      url,
+      raxConfig: {noResponseRetries: 0},
+    };
+    try {
+      await axios(config);
+    } catch (e) {
+      const cfg = rax.getConfig(e);
+      assert.strictEqual(cfg!.noResponseRetries, 0);
+      scope.isDone();
+      return;
+    }
+    assert.fail('Expected to throw');
+  });
 });


### PR DESCRIPTION
This PR allows to use retryDelay as 0. Currently if the value is 0 it will use the default value (100).

Got the idea after using retryDelay: 0 and wondering why it was taking so long.

May cause backwards incompatibility?

Edit: Well, it didn't even pass the CI, so yes.

Edit 2: Changed to ternary operator.