### PR TITLE
feat: support retry-after header

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@babel/preset-env": "^7.4.5",
     "@types/mocha": "^8.0.0",
     "@types/node": "^12.0.4",
+    "@types/sinon": "^9.0.10",
     "axios": "^0.21.0",
     "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
     "c8": "^7.0.0",
@@ -51,6 +52,7 @@
     "mocha": "^8.0.0",
     "nock": "^13.0.0",
     "semantic-release": "^17.0.4",
+    "sinon": "^9.2.4",
     "typescript": "~4.1.0"
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,16 @@ export interface RetryConfig {
    * Backoff Type; 'linear', 'static' or 'exponential'.
    */
   backoffType?: 'linear' | 'static' | 'exponential';
+
+  /**
+   * Whether to check for 'Retry-After' header in response and use value as delay. Defaults to true.
+   */
+  checkRetryAfter?: boolean;
+
+  /**
+   * Max permitted Retry-After value (in ms) - rejects if greater. Defaults to 5 mins.
+   */
+  maxRetryAfter?: number;
 }
 
 export type RaxConfig = {
@@ -124,6 +134,26 @@ function normalizeArray<T>(obj?: T[]): T[] | undefined {
   return arr;
 }
 
+/**
+ * Parse the Retry-After header.
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
+ * @param header Retry-After header value
+ * @returns Number of milliseconds, or undefined if invalid
+ */
+function parseRetryAfter(header: string): number | undefined {
+  // Header value may be string containing integer seconds
+  const value = parseInt(header);
+  if (!Number.isNaN(value)) {
+    return value * 1000;
+  }
+  // Or HTTP date time string
+  const dateTime = Date.parse(header);
+  if (!Number.isNaN(dateTime)) {
+    return dateTime - Date.now() + 3000; // Add 3sec buffer
+  }
+  return undefined;
+}
+
 function onError(err: AxiosError) {
   if (axios.isCancel(err)) {
     return Promise.reject(err);
@@ -145,6 +175,10 @@ function onError(err: AxiosError) {
   ];
   config.noResponseRetries =
     typeof config.noResponseRetries === 'number' ? config.noResponseRetries : 2;
+  config.checkRetryAfter =
+    typeof config.checkRetryAfter === 'boolean' ? config.checkRetryAfter : true;
+  config.maxRetryAfter =
+    typeof config.maxRetryAfter === 'number' ? config.maxRetryAfter : 60000 * 5;
 
   // If this wasn't in the list of status codes where we want
   // to automatically retry, return.
@@ -174,18 +208,32 @@ function onError(err: AxiosError) {
   }
 
   // Create a promise that invokes the retry after the backOffDelay
-  const onBackoffPromise = new Promise(resolve => {
-    // Calculate time to wait with exponential backoff.
-    // Formula: (2^c - 1 / 2) * 1000
-    let delay: number;
-    if (config.backoffType === 'linear') {
-      delay = config.currentRetryAttempt! * 1000;
-    } else if (config.backoffType === 'static') {
-      delay = config.retryDelay!;
-    } else {
-      delay = ((Math.pow(2, config.currentRetryAttempt!) - 1) / 2) * 1000;
+  const onBackoffPromise = new Promise((resolve, reject) => {
+    let delay = 0;
+    // If enabled, check for 'Retry-After' header in response to use as delay
+    if (
+      config.checkRetryAfter &&
+      err.response &&
+      err.response.headers['retry-after']
+    ) {
+      const retryAfter = parseRetryAfter(err.response.headers['retry-after']);
+      if (retryAfter && retryAfter > 0 && retryAfter <= config.maxRetryAfter!) {
+        delay = retryAfter;
+      } else {
+        return reject(err);
+      }
     }
-
+    // Else calculate delay according to chosen strategy
+    // Default to exponential backoff - formula: (2^c - 1 / 2) * 1000
+    else {
+      if (config.backoffType === 'linear') {
+        delay = config.currentRetryAttempt! * 1000;
+      } else if (config.backoffType === 'static') {
+        delay = config.retryDelay!;
+      } else {
+        delay = ((Math.pow(2, config.currentRetryAttempt!) - 1) / 2) * 1000;
+      }
+    }
     // We're going to retry!  Incremenent the counter.
     (err.config as RaxConfig).raxConfig!.currentRetryAttempt! += 1;
     setTimeout(resolve, delay);

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,14 +142,14 @@ function normalizeArray<T>(obj?: T[]): T[] | undefined {
  */
 function parseRetryAfter(header: string): number | undefined {
   // Header value may be string containing integer seconds
-  const value = parseInt(header);
+  const value = Number(header);
   if (!Number.isNaN(value)) {
     return value * 1000;
   }
   // Or HTTP date time string
   const dateTime = Date.parse(header);
   if (!Number.isNaN(dateTime)) {
-    return dateTime - Date.now() + 3000; // Add 3sec buffer
+    return dateTime - Date.now();
   }
   return undefined;
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -401,7 +401,8 @@ describe('retry-axios', () => {
     assert.fail('Expected to throw');
   });
 
-  it('should retry with Retry-After header in seconds', async () => {
+  it('should retry with Retry-After header in seconds', async function () {
+    this.timeout(1000); // Short timeout to trip test if delay longer than expected
     const scopes = [
       nock(url).get('/').reply(429, undefined, {
         'Retry-After': '5',
@@ -426,9 +427,10 @@ describe('retry-axios', () => {
     const res = await axiosPromise;
     assert.strictEqual(res.data, 'toast');
     scopes.forEach(s => s.done());
-  }).timeout(1000); // Short timeout to trip test if delay longer than expected
+  });
 
-  it('should retry with Retry-After header in http datetime', async () => {
+  it('should retry with Retry-After header in http datetime', async function () {
+    this.timeout(1000);
     const scopes = [
       nock(url).get('/').reply(429, undefined, {
         'Retry-After': 'Thu, 01 Jan 1970 00:00:05 UTC',
@@ -453,7 +455,7 @@ describe('retry-axios', () => {
     const res = await axiosPromise;
     assert.strictEqual(res.data, 'toast');
     scopes.forEach(s => s.done());
-  }).timeout(1000);
+  });
 
   it('should not retry if Retry-After greater than maxRetryAfter', async () => {
     const scopes = [

--- a/test/index.ts
+++ b/test/index.ts
@@ -5,7 +5,6 @@ import * as sinon from 'sinon';
 import {describe, it, afterEach} from 'mocha';
 import * as rax from '../src';
 import {RaxConfig} from '../src';
-import 'mocha';
 
 const url = 'http://test.local';
 
@@ -83,7 +82,8 @@ describe('retry-axios', () => {
     assert.fail('Expected to throw');
   });
 
-  it('should retry at least the configured number of times', async () => {
+  it('should retry at least the configured number of times', async function () {
+    this.timeout(10000);
     const scopes = [
       nock(url).get('/').times(3).reply(500),
       nock(url).get('/').reply(200, 'milk'),
@@ -93,7 +93,7 @@ describe('retry-axios', () => {
     const res = await axios(cfg);
     assert.strictEqual(res.data, 'milk');
     scopes.forEach(s => s.done());
-  }).timeout(10000);
+  });
 
   it('should not retry more than configured', async () => {
     const scope = nock(url).get('/').twice().reply(500);
@@ -402,7 +402,8 @@ describe('retry-axios', () => {
     assert.fail('Expected to throw');
   });
 
-  it('should retry with Retry-After header in seconds', async () => {
+  it('should retry with Retry-After header in seconds', async function () {
+    this.timeout(1000); // Short timeout to trip test if delay longer than expected
     const scopes = [
       nock(url).get('/').reply(429, undefined, {
         'Retry-After': '5',
@@ -427,9 +428,10 @@ describe('retry-axios', () => {
     const res = await axiosPromise;
     assert.strictEqual(res.data, 'toast');
     scopes.forEach(s => s.done());
-  }).timeout(1000);
+  });
 
-  it('should retry with Retry-After header in http datetime', async () => {
+  it('should retry with Retry-After header in http datetime', async function () {
+    this.timeout(1000);
     const scopes = [
       nock(url).get('/').reply(429, undefined, {
         'Retry-After': 'Thu, 01 Jan 1970 00:00:05 UTC',
@@ -454,7 +456,7 @@ describe('retry-axios', () => {
     const res = await axiosPromise;
     assert.strictEqual(res.data, 'toast');
     scopes.forEach(s => s.done());
-  }).timeout(1000);
+  });
 
   it('should not retry if Retry-After greater than maxRetryAfter', async () => {
     const scopes = [

--- a/test/index.ts
+++ b/test/index.ts
@@ -5,6 +5,7 @@ import * as sinon from 'sinon';
 import {describe, it, afterEach} from 'mocha';
 import * as rax from '../src';
 import {RaxConfig} from '../src';
+import 'mocha';
 
 const url = 'http://test.local';
 
@@ -401,8 +402,7 @@ describe('retry-axios', () => {
     assert.fail('Expected to throw');
   });
 
-  it('should retry with Retry-After header in seconds', async function () {
-    this.timeout(1000); // Short timeout to trip test if delay longer than expected
+  it('should retry with Retry-After header in seconds', async () => {
     const scopes = [
       nock(url).get('/').reply(429, undefined, {
         'Retry-After': '5',
@@ -427,10 +427,9 @@ describe('retry-axios', () => {
     const res = await axiosPromise;
     assert.strictEqual(res.data, 'toast');
     scopes.forEach(s => s.done());
-  });
+  }).timeout(1000);
 
-  it('should retry with Retry-After header in http datetime', async function () {
-    this.timeout(1000);
+  it('should retry with Retry-After header in http datetime', async () => {
     const scopes = [
       nock(url).get('/').reply(429, undefined, {
         'Retry-After': 'Thu, 01 Jan 1970 00:00:05 UTC',
@@ -455,7 +454,7 @@ describe('retry-axios', () => {
     const res = await axiosPromise;
     assert.strictEqual(res.data, 'toast');
     scopes.forEach(s => s.done());
-  });
+  }).timeout(1000);
 
   it('should not retry if Retry-After greater than maxRetryAfter', async () => {
     const scopes = [


### PR DESCRIPTION
Adds functionality to check for Retry-After header in error response and parse the value if it's available (as per https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After)

- Handles number and Date header values
- Delays by parsed value up to max number of retries
- Rejects immediately if header value could not be parsed/is invalid
- Rejects immediately if header value is greater than configured `maxRetryAfter` (default 5 mins)
- Feature can be toggled off via `checkRetryAfter` config param