### PR TITLE
docs: exponential backoff formula in comment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -224,7 +224,7 @@ function onError(err: AxiosError) {
       }
     }
     // Else calculate delay according to chosen strategy
-    // Default to exponential backoff - formula: ((2^c - 1 / 2) * 1000)
+    // Default to exponential backoff - formula: ((2^c - 1) / 2) * 1000
     else {
       if (config.backoffType === 'linear') {
         delay = config.currentRetryAttempt! * 1000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,7 @@ function onError(err: AxiosError) {
   // Create a promise that invokes the retry after the backOffDelay
   const onBackoffPromise = new Promise(resolve => {
     // Calculate time to wait with exponential backoff.
-    // Formula: (2^c - 1 / 2) * 1000
+    // Formula: ((2^c - 1) / 2) * 1000
     let delay: number;
     if (config.backoffType === 'linear') {
       delay = config.currentRetryAttempt! * 1000;


### PR DESCRIPTION
The formula in the code has an extra set of parentheses that are not in the comment.