### PR TITLE
feat: add 'onFail(error)' called when failure of all retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ const res = await axios({
     onRetryAttempt: err => {
       const cfg = rax.getConfig(err);
       console.log(`Retry attempt #${cfg.currentRetryAttempt}`);
+    },
+    
+    // Function to invoke when all retries fail.
+    onFail: err => {
+      // you can send log to logging server
+      // also, display toast message
     }
   }
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,10 +157,6 @@ function parseRetryAfter(header: string): number | undefined {
 }
 
 function onError(err: AxiosError) {
-  if (axios.isCancel(err)) {
-    return Promise.reject(err);
-  }
-
   const config = getConfig(err) || {};
   config.currentRetryAttempt = config.currentRetryAttempt || 0;
   config.retry = typeof config.retry === 'number' ? config.retry : 3;

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,7 +288,9 @@ export function shouldRetryRequest(err: AxiosError) {
   // to automatically retry, return.
   if (err.response && err.response.status) {
     const status = err.response.status;
-    const isInRange = config.statusCodesToRetry!.some(([min, max]) => min <= status && status <= max);
+    const isInRange = config.statusCodesToRetry!.some(
+      ([min, max]) => min <= status && status <= max
+    );
     if (!isInRange) {
       return false;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,6 @@ function onFulfilled(res: AxiosResponse) {
  * @returns An array with the pucked values
  */
 function normalizeArray<T>(obj?: T[]): T[] | undefined {
-  const arr: T[] = [];
   if (!obj) {
     return undefined;
   }
@@ -130,13 +129,11 @@ function normalizeArray<T>(obj?: T[]): T[] | undefined {
     return obj;
   }
   if (typeof obj === 'object') {
-    Object.keys(obj).forEach(key => {
-      if (typeof key === 'number') {
-        arr[key] = obj[key];
-      }
-    });
+    return Object.keys(obj)
+      .filter(key => !!obj[key])
+      .map(key => obj[key]);
   }
-  return arr;
+  return [];
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -297,11 +297,7 @@ export function shouldRetryRequest(err: AxiosError) {
 
   // If we are out of retry attempts, return
   config.currentRetryAttempt = config.currentRetryAttempt || 0;
-  if (config.currentRetryAttempt >= config.retry!) {
-    return false;
-  }
-
-  return true;
+  return config.currentRetryAttempt < config.retry!;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -282,14 +282,8 @@ export function shouldRetryRequest(err: AxiosError) {
   // If this wasn't in the list of status codes where we want
   // to automatically retry, return.
   if (err.response && err.response.status) {
-    let isInRange = false;
-    for (const [min, max] of config.statusCodesToRetry!) {
-      const status = err.response.status;
-      if (status >= min && status <= max) {
-        isInRange = true;
-        break;
-      }
-    }
+    const status = err.response.status;
+    const isInRange = config.statusCodesToRetry!.some(([min, max]) => min <= status && status <= max);
     if (!isInRange) {
       return false;
     }

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import axios, { AxiosError, AxiosRequestConfig } from 'axios'
+import axios, {AxiosError, AxiosRequestConfig} from 'axios';
 import * as nock from 'nock';
 import * as sinon from 'sinon';
 import {describe, it, afterEach} from 'mocha';
@@ -470,10 +470,14 @@ describe('retry-axios', () => {
   });
 
   it('should config.onFail() called if all retry failed', async () => {
-    const scope = nock(url).get('/').times(2).reply(500, {errorMessage: 'ErrorMessage'});
-    const onFail = sinon.spy((_: AxiosError) => {})
+    const scope = nock(url)
+      .get('/')
+      .times(2)
+      .reply(500, {errorMessage: 'ErrorMessage'});
+    /* eslint @typescript-eslint/no-unused-vars: 0 */
+    const onFail = sinon.spy((_: AxiosError) => {});
     interceptorId = rax.attach();
-    const cfg: rax.RaxConfig = { url, raxConfig: {retry: 1, onFail}};
+    const cfg: rax.RaxConfig = {url, raxConfig: {retry: 1, onFail}};
     try {
       await axios(cfg);
     } catch (e) {
@@ -481,14 +485,15 @@ describe('retry-axios', () => {
       sinon.assert.calledOnceWithExactly(onFail, e);
     }
 
-    scope.done()
+    scope.done();
   });
 
   it('should throw error in onFail() called if all retry failed when the network is unavailable', async () => {
-    nock.disableNetConnect()
-    const onFail = sinon.spy((_: AxiosError) => {})
+    nock.disableNetConnect();
+    /* eslint @typescript-eslint/no-unused-vars: 0 */
+    const onFail = sinon.spy((_: AxiosError) => {});
     interceptorId = rax.attach();
-    const cfg: rax.RaxConfig = { url, raxConfig: {onFail}};
+    const cfg: rax.RaxConfig = {url, raxConfig: {onFail}};
     try {
       await axios(cfg);
     } catch (e) {
@@ -498,12 +503,17 @@ describe('retry-axios', () => {
   });
 
   it('should throw the error by axios to the caller, if an error occurs in onFail()', async () => {
-    const scope = nock(url).get('/').times(2).reply(500, {errorMessage: 'ErrorMessage'});
-    const errorThrownByOnFail = new Error('Error in onFail()')
-    const onFail = sinon.spy((_: AxiosError) => {throw errorThrownByOnFail})
+    const scope = nock(url)
+      .get('/')
+      .times(2)
+      .reply(500, {errorMessage: 'ErrorMessage'});
+    const errorThrownByOnFail = new Error('Error in onFail()');
+    /* eslint @typescript-eslint/no-unused-vars: 0 */
+    const onFail = sinon.spy((_: AxiosError) => {
+      throw errorThrownByOnFail;
+    });
     interceptorId = rax.attach();
-    const cfg: rax.RaxConfig = { url, raxConfig: {retry: 1, onFail}};
-    // await assert.rejects(axios(cfg))
+    const cfg: rax.RaxConfig = {url, raxConfig: {retry: 1, onFail}};
     try {
       await axios(cfg);
     } catch (e) {
@@ -511,7 +521,7 @@ describe('retry-axios', () => {
       assert.notDeepStrictEqual(e, errorThrownByOnFail);
       assert.deepStrictEqual(e.response.data, {errorMessage: 'ErrorMessage'});
     }
-    scope.done()
+    scope.done();
   });
 });
 


### PR DESCRIPTION
Add a `onFail()`(`callback function`) to **be called when all retries have failed**.

Of course, the case where `all retries failed` can be handled in `shouldRetry()`. 
or, each `caller` `attempting an axios request ` could also do it with a `try-catch`.

But I think `shouldRetry()` **never should be responsible for handling the all 'retry' failure case**. 
In addition, the same post-processing may be required when all retries have failed. (such as sending an error log to a server)
If there is no `onFail callback function` for every retry failure, `all axios callers` must handle the same exception.

**So, I think we need an `onFail() callback function` that gets called in case all retries fail.**

---

Also, refactored `shouldRetryRequest(err: AxisError)`, `normalizeArray<T>(obj?: T[])`.  3664105, e0e5d24, ac7cb64