### PR TITLE
fix: non-zero delay between first attempt and first retry for linear and exp strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "unpkg": "dist/index.umd.js",
   "types": "dist/src/index.d.ts",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=10.7.0"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,20 +239,24 @@ function onError(err: AxiosError) {
     // below.
     (err.config as RaxConfig).raxConfig!.currentRetryAttempt! += 1;
 
+    // store with shorter and more expressive variable name.
+    const retrycount = (err.config as RaxConfig).raxConfig!
+      .currentRetryAttempt!;
+
     // Calculate delay according to chosen strategy
     // Default to exponential backoff - formula: ((2^c - 1) / 2) * 1000
     if (delay === 0) {
       // was not set by Retry-After logic
       if (config.backoffType === 'linear') {
-        // The delay between the first (actual) attempt and the
-        // first retry should be non-zero. That is, by definition
-        // config.currentRetryAttempt must equal to 1 for the first
-        // retry (was once 0-based, which is a bug -- see #122).
-        delay = config.currentRetryAttempt! * 1000;
+        // The delay between the first (actual) attempt and the first retry
+        // should be non-zero. Rely on the convention that `retrycount` is
+        // equal to 1 for the first retry when we are in here (was once 0,
+        // which was a bug -- see #122).
+        delay = retrycount * 1000;
       } else if (config.backoffType === 'static') {
         delay = config.retryDelay!;
       } else {
-        delay = ((Math.pow(2, config.currentRetryAttempt!) - 1) / 2) * 1000;
+        delay = ((Math.pow(2, retrycount) - 1) / 2) * 1000;
       }
     }
     setTimeout(resolve, delay);

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,11 +227,12 @@ function onError(err: AxiosError) {
     // Now it's certain that a retry is supposed to happen.
     // Incremenent the counter, critical for linear and exp
     // backoff delay calc.
-    (err.config as RaxConfig).raxConfig!.currentRetryAttempt! += 1;
+    config.currentRetryAttempt! += 1;
 
     // Calculate delay according to chosen strategy
     // Default to exponential backoff - formula: ((2^c - 1) / 2) * 1000
-    if (delay === 0) { // was not set by Retry-After logic
+    if (delay === 0) {
+      // was not set by Retry-After logic
       if (config.backoffType === 'linear') {
         // The delay between the first (actual) attempt and the
         // first retry should be non-zero. That is, by definition


### PR DESCRIPTION
One of the issues discussed in #122 is that for the `linear` and `exponential` strategy the delay between the first and second HTTP request is 0.

This PR:

- makes this first delay non-zero by moving `(err.config as RaxConfig).raxConfig!.currentRetryAttempt! += 1;` to _before_ doing the math that uses the result.
- introduces the variable `retrycount` and adds a comment explaining what it really means to make future work on this code section a little more straight-forward. 
- adds one new test for each of the strategies, explicitly measuring the delay time between first and second HTTP request 

Note that for measuring time difference I wanted to use a monotonic time source and the "modern" `process.hrtime.bigint()` and therefore I was bumping the `engine` in `package.json`.

The duration of `npm run test` changed from ~7 s to ~27 s because of the delay now hitting in.

@JustinBeckwith I would appreciate review!

Note that next up we can maybe change the time constants for the exponential backoff as was also proposed in #122; to make the first delay a little smaller than 0.5 seconds.