### PR TITLE
build!: drop support for node 16

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 16, 18, 20]
+        node: [18, 20]
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
       - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "types": "./build/src/index.d.ts",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
BREAKING CHANGE: This library now requires Node.js 18 and up, as Node.js has reached EOL. 