### PR TITLE
Add support for commonjs

### DIFF
--- a/add-module-package-json.sh
+++ b/add-module-package-json.sh
@@ -1,0 +1,13 @@
+#! /bin/sh
+
+cat > build/cjs/package.json << !EOF
+{
+    "type": "commonjs"
+}
+!EOF
+
+cat > build/esm/package.json << !EOF
+{
+    "type": "module"
+}
+!EOF

--- a/package.json
+++ b/package.json
@@ -2,9 +2,15 @@
   "name": "retry-axios",
   "version": "0.0.0",
   "description": "Retry HTTP requests with Axios.",
-  "exports": "./build/src/index.js",
-  "type": "module",
-  "types": "./build/src/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./build/cjs/index.js",
+      "import": "./build/esm/index.js"
+    }
+  },
+  "main": "build/cjs/index.js",
+  "module": "build/esm/index.js",
+  "types": "build/types/index.d.ts",
   "engines": {
     "node": ">=18"
   },
@@ -15,8 +21,8 @@
   "scripts": {
     "lint": "xo --prettier",
     "fix": "xo --prettier --fix",
-    "compile": "tsc -p .",
-    "test": "c8 mocha build/test",
+    "compile": "tsc -b ./tsconfig-cjs.json ./tsconfig-esm.json ./tsconfig-types.json && sh ./add-module-package-json.sh",
+    "test": "c8 mocha --require ts-node/register test/**/*.ts",
     "pretest": "npm run compile",
     "license-check": "jsgl --local ."
   },
@@ -42,18 +48,13 @@
     "nock": "^13.3.0",
     "semantic-release": "^22.0.0",
     "sinon": "^17.0.0",
+    "ts-node": "^10.9.1",
     "typescript": "~5.3.0",
     "xo": "^0.56.0"
   },
   "files": [
-    "build/src"
+    "build/*"
   ],
-  "c8": {
-    "exclude": [
-      "build/test",
-      "dist"
-    ]
-  },
   "xo": {
     "rules": {
       "@typescript-eslint/prefer-nullish-coalescing": "off",

--- a/test/index.ts
+++ b/test/index.ts
@@ -4,8 +4,7 @@ import axios, {type AxiosError, type AxiosRequestConfig} from 'axios';
 import nock from 'nock';
 import * as sinon from 'sinon';
 import {describe, it, afterEach} from 'mocha';
-import * as rax from '../src/index.js';
-import {type RaxConfig} from '../src/index.js';
+import * as rax from '../src';
 
 const url = 'http://test.local';
 
@@ -293,7 +292,7 @@ describe('retry-axios', () => {
 		];
 		const ax = axios.create();
 		interceptorId = rax.attach(ax);
-		const cfg: RaxConfig = {raxConfig: {instance: ax}};
+		const cfg: rax.RaxConfig = {raxConfig: {instance: ax}};
 		const result = await ax.get(url, cfg);
 		assert.strictEqual(result.data, 'raisins');
 		for (const s of scopes) {
@@ -396,7 +395,7 @@ describe('retry-axios', () => {
 		];
 		interceptorId = rax.attach();
 		let flipped = false;
-		const config: RaxConfig = {
+		const config: rax.RaxConfig = {
 			url,
 			raxConfig: {
 				onRetryAttempt(error) {
@@ -420,7 +419,7 @@ describe('retry-axios', () => {
 		];
 		interceptorId = rax.attach();
 		let flipped = false;
-		const config: RaxConfig = {
+		const config: rax.RaxConfig = {
 			url,
 			raxConfig: {
 				async onRetryAttempt(error) {
@@ -443,7 +442,7 @@ describe('retry-axios', () => {
 	it('should support overriding the shouldRetry method', async () => {
 		const scope = nock(url).get('/').reply(500);
 		interceptorId = rax.attach();
-		const config: RaxConfig = {
+		const config: rax.RaxConfig = {
 			url,
 			raxConfig: {
 				shouldRetry(error) {

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./build/cjs",
+    "module": "commonjs"
+  }
+}

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./build/esm",
+    "module": "esnext",
+  }
+}

--- a/tsconfig-types.json
+++ b/tsconfig-types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./build/types",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,14 @@
 {
   "compilerOptions": {
     "strict": true,
-    "declaration": true,
+    "declaration": false,
     "sourceMap": true,
     "target": "ES2022",
-    "rootDir": ".",
-    "outDir": "build",
     "moduleResolution": "node",
-    "module": "ES2022",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "outDir": "./build"
   },
   "include": [
-    "src/*.ts",
-    "test/*.ts"
+    "src",
   ]
 }


### PR DESCRIPTION
Currently, this module is not importable in NodeJS applications that are using commonjs module resolution. In order to support them I've added a separate tsconfig file that builds not only ecmascript module but also commonjs module. The steps taken to support both approaches are described in https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html.
On top of that, I've also changed tests so they don't require to be built. I've added `ts-node` that can be run together with `mocha` and tests can be run immediately.