### PR TITLE
fix: Call onRetryAttempt *after* backoff timeout

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -630,7 +630,7 @@ describe('retry-axios', () => {
 		const axiosPromise = axios({
 			url,
 			raxConfig: {
-				onRetryAttempt: resolve,
+				onError: resolve,
 				retryDelay: 10_000, // Higher default to ensure Retry-After is used
 				backoffType: 'static',
 			},
@@ -660,7 +660,7 @@ describe('retry-axios', () => {
 		const axiosPromise = axios({
 			url,
 			raxConfig: {
-				onRetryAttempt: resolve,
+				onError: resolve,
 				backoffType: 'static',
 				retryDelay: 10_000,
 			},
@@ -710,7 +710,7 @@ describe('retry-axios', () => {
 		const axiosPromise = axios({
 			url,
 			raxConfig: {
-				onRetryAttempt: resolve,
+				onError: resolve,
 				retryDelay: 10_000, // Higher default to ensure maxRetryDelay is used
 				maxRetryDelay: 5000,
 				backoffType: 'exponential',


### PR DESCRIPTION
The log appears before the timeout, which is misleading.

Also return support for async onRetryAttempt.

Fixes #119.