### PR TITLE
fix: avoid circular error serialization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,6 +188,19 @@ function normalizeArray<T>(object?: T[]): T[] | undefined {
 	return array;
 }
 
+function setConfigMetadata(config: RetryConfig, errors: AxiosError[]) {
+	config.errors = errors;
+	Object.defineProperty(config, 'toJSON', {
+		value(this: RetryConfig) {
+			const { errors: _errors, ...serializedConfig } = this;
+			return serializedConfig;
+		},
+		writable: true,
+		configurable: true,
+		enumerable: false,
+	});
+}
+
 /**
  * Parse the Retry-After header.
  * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
@@ -246,12 +259,11 @@ async function onError(instance: AxiosInstance, error: AxiosError) {
 	(axiosError.config as RaxConfig).raxConfig = { ...config };
 
 	// Initialize errors array on first error, or append to existing array
-	if (!config.errors) {
-		config.errors = [axiosError];
-		(axiosError.config as RaxConfig).raxConfig.errors = config.errors;
-	} else {
-		config.errors.push(axiosError);
-	}
+	const errors = config.errors ?? [];
+	errors.push(axiosError);
+
+	setConfigMetadata(config, errors);
+	setConfigMetadata((axiosError.config as RaxConfig).raxConfig, errors);
 
 	// Determine if we should retry the request
 	// First check the retry count limit, then apply custom logic if provided

--- a/test/index.ts
+++ b/test/index.ts
@@ -1117,6 +1117,36 @@ describe('retry-axios', () => {
 		}
 	});
 
+	it('should allow serializing the final error when errors are tracked', async () => {
+		const scopes = [
+			nock(url).get('/').reply(500, 'Error 1'),
+			nock(url).get('/').reply(500, 'Error 2'),
+		];
+
+		interceptorId = rax.attach();
+		try {
+			await axios({
+				url,
+				raxConfig: {
+					retry: 1,
+					retryDelay: 1,
+				},
+			});
+			assert.fail('Expected to throw');
+		} catch (error) {
+			const axiosError = error as AxiosError;
+			const config = rax.getConfig(axiosError);
+
+			for (const s of scopes) {
+				s.done();
+			}
+
+			assert.ok(config?.errors, 'errors array should exist');
+			assert.strictEqual(config.errors.length, 2);
+			assert.doesNotThrow(() => JSON.stringify(axiosError));
+		}
+	});
+
 	it('should track retriesRemaining correctly', async () => {
 		const scopes = [
 			nock(url).get('/').reply(500),


### PR DESCRIPTION
## Summary
- avoid recursive `raxConfig.errors` serialization by giving retry config a safe `toJSON()`
- preserve the existing `errors` retry history for runtime access
- add a regression test covering `JSON.stringify(error)` after retries

Fixes #347.

## Testing
- npm run lint
- npm run typecheck
- npm test
